### PR TITLE
hotfix(deps): Use ipykernel v6 in all Python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2450,7 +2450,6 @@ description = "IPython Kernel for Jupyter"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\""
 files = [
     {file = "ipykernel-6.31.0-py3-none-any.whl", hash = "sha256:abe5386f6ced727a70e0eb0cf1da801fa7c5fa6ff82147747d5a0406cd8c94af"},
     {file = "ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6"},
@@ -2474,41 +2473,6 @@ traitlets = ">=5.4.0"
 [package.extras]
 cov = ["coverage[toml]", "matplotlib", "pytest-cov", "trio"]
 docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
-pyqt5 = ["pyqt5"]
-pyside6 = ["pyside6"]
-test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<9)", "pytest-asyncio (>=0.23.5)", "pytest-cov", "pytest-timeout"]
-
-[[package]]
-name = "ipykernel"
-version = "7.1.0"
-description = "IPython Kernel for Jupyter"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version >= \"3.10\""
-files = [
-    {file = "ipykernel-7.1.0-py3-none-any.whl", hash = "sha256:763b5ec6c5b7776f6a8d7ce09b267693b4e5ce75cb50ae696aaefb3c85e1ea4c"},
-    {file = "ipykernel-7.1.0.tar.gz", hash = "sha256:58a3fc88533d5930c3546dc7eac66c6d288acde4f801e2001e65edc5dc9cf0db"},
-]
-
-[package.dependencies]
-appnope = {version = ">=0.1.2", markers = "platform_system == \"Darwin\""}
-comm = ">=0.1.1"
-debugpy = ">=1.6.5"
-ipython = ">=7.23.1"
-jupyter-client = ">=8.0.0"
-jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
-matplotlib-inline = ">=0.1"
-nest-asyncio = ">=1.4"
-packaging = ">=22"
-psutil = ">=5.7"
-pyzmq = ">=25"
-tornado = ">=6.2"
-traitlets = ">=5.4.0"
-
-[package.extras]
-cov = ["coverage[toml]", "matplotlib", "pytest-cov", "trio"]
-docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx (<8.2.0)", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
 pyqt5 = ["pyqt5"]
 pyside6 = ["pyside6"]
 test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<9)", "pytest-asyncio (>=0.23.5)", "pytest-cov", "pytest-timeout"]
@@ -7391,4 +7355,4 @@ server = ["deepnote-python-lsp-server", "jupyter-resource-usage", "jupyter-serve
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,<3.14,!=3.9.7"
-content-hash = "36c79326793c8e8fa75607272719f97ae01261a6911883c3c99c2255d5ea26dc"
+content-hash = "1f130b5dd4d909faaca0ae2874ea688283574fd8a658bdb8ab75b32a89cb45ac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ dependencies = [
     # SQL templating
     "jinja2>=3.1.6,<4",
     "sqlparse>=0.4.4,<0.6",
-    "ipykernel>6.30.0",
     "pymysql>=1.1.1,<1.2",
     "pymongo>=4.6.3,<4.10; python_version < '3.13'",
     "pymongo>=4.9.0,<5; python_version>='3.13'",
@@ -118,6 +117,10 @@ dependencies = [
     "nbformat>=5.10.4,<6",
     "typing-extensions>=4.12.2,<5.0.0",
     "wrapt>=1.12.0",
+    
+    # Jupyter & IPython dependencies
+    "ipykernel>=6.30.1,<7",
+    "jupyter-core>=5.8.1,<6",
 
     # Visualization
     # NOTE: 1.7.0 is latest version of vl-convert which ships with Vega 5. In webapp we can't update to Vega 6 due to ESM-only issues
@@ -135,7 +138,6 @@ dependencies = [
     "cryptography>=44.0.1,<45; python_version >= '3.10'",
     "protobuf>=4.25.8,<6",
     "requests>=2.32.4,<3",
-    "jupyter-core>=5.8.1,<6",
     "tornado>=6.5,<7",
 
     # Config dependencies - they need to be declared both in main and server extras, keep them in sync


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to maintain compatibility and ensure system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->