### PR TITLE
fix(cd): Release to staging sequentially to prevent Git conflicts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -455,6 +455,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-toolkit-cluster-cache
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    concurrency:
+      # run the job sequentially to prevent Git conflicts from update-config-version action
+      # (GitHub queues only 1 job at a time for the same concurrency group, which is fine)
+      group: release-staging
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4


### PR DESCRIPTION
run the job sequentially to prevent Git conflicts from `update-config-version` action

e.g. main and tagged release trigger CD job(s), the second job gets a conflict as it has checked out the branch before first job's commit has been automatically merged (first action already merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to ensure sequential processing, reducing the risk of conflicts during deployment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->