### PR TITLE
ci(cd): send production bump PR links to slack 

### DIFF
--- a/.github/actions/update-config-version/action.yml
+++ b/.github/actions/update-config-version/action.yml
@@ -274,7 +274,9 @@ runs:
         if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
           {
             echo "pr_url=$PR_URL"
-            echo "error_message=$ERROR_MESSAGE"
+            echo "error_message<<EOF"
+            echo "$ERROR_MESSAGE"
+            echo "EOF"
           } >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/actions/update-config-version/action.yml
+++ b/.github/actions/update-config-version/action.yml
@@ -21,6 +21,13 @@ inputs:
   target_repo:
     description: 'Target repository name'
     required: true
+outputs:
+  pr_url:
+    description: 'URL of the created or updated PR'
+    value: ${{ steps.octopilot.outputs.pr_url }}
+  error_message:
+    description: 'Error message if octopilot failed'
+    value: ${{ steps.octopilot.outputs.error_message }}
 runs:
   using: 'composite'
   steps:
@@ -70,6 +77,8 @@ runs:
         octopilot --version
 
     - name: Update version using octopilot
+      id: octopilot
+      continue-on-error: true
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -78,11 +87,6 @@ runs:
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_MERGE: ${{ inputs.merge }}
         INPUT_VERSIONS: ${{ inputs.versions }}
-        GITHUB_SERVER_URL: ${{ github.server_url }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_RUN_ID: ${{ github.run_id }}
-        GITHUB_SHA: ${{ github.sha }}
-        GITHUB_ACTOR: ${{ github.actor }}
       run: |
         set -euo pipefail
 
@@ -253,4 +257,30 @@ runs:
           "--fail-on-error"
         )
 
+        set +e
         octopilot "${octopilot_args[@]}"
+        OCTOPILOT_EXIT_CODE=$?
+        set -e
+
+        # Extract PR URL and error message from octopilot output
+        PR_URL=""
+        ERROR_MESSAGE=""
+        if [[ -f octopilot-output.json ]]; then
+          PR_URL="$(jq -r '.repos[0].pr.url // empty' octopilot-output.json 2>/dev/null || echo "")"
+          ERROR_MESSAGE="$(jq -r '.repos[0].error // empty' octopilot-output.json 2>/dev/null || echo "")"
+          echo "PR URL: $PR_URL"
+        fi
+
+        if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+          {
+            echo "pr_url=$PR_URL"
+            echo "error_message=$ERROR_MESSAGE"
+          } >> "$GITHUB_OUTPUT"
+        fi
+
+        exit $OCTOPILOT_EXIT_CODE
+
+    - name: Fail if octopilot failed
+      if: steps.octopilot.outcome == 'failure'
+      shell: bash
+      run: exit 1

--- a/.github/actions/update-config-version/action.yml
+++ b/.github/actions/update-config-version/action.yml
@@ -265,6 +265,7 @@ runs:
         # Extract PR URL and error message from octopilot output
         PR_URL=""
         ERROR_MESSAGE=""
+        OUTPUT_DELIMITER="GITHUB_OUTPUT_$(uuidgen)"
         if [[ -f octopilot-output.json ]]; then
           PR_URL="$(jq -r '.repos[0].pr.url // empty' octopilot-output.json 2>/dev/null || echo "")"
           ERROR_MESSAGE="$(jq -r '.repos[0].error // empty' octopilot-output.json 2>/dev/null || echo "")"
@@ -274,9 +275,9 @@ runs:
         if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
           {
             echo "pr_url=$PR_URL"
-            echo "error_message<<EOF"
+            echo "error_message<<$OUTPUT_DELIMITER"
             echo "$ERROR_MESSAGE"
-            echo "EOF"
+            echo "$OUTPUT_DELIMITER"
           } >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -511,6 +511,7 @@ jobs:
         uses: ./.github/actions/export-version
 
       - name: Update production version
+        id: update-ops
         uses: ./.github/actions/update-config-version
         with:
           env: production
@@ -521,7 +522,32 @@ jobs:
           branch: master
           github_token: ${{ secrets.DEEPNOTE_BOT_USER_TOKEN }}
 
+      - name: Notify Slack - ops production PR created
+        if: always() && steps.update-ops.outcome == 'success' && steps.update-ops.outputs.pr_url != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_PRODUCTION }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "icon_emoji": ":deepnote:",
+              "text": ":loading: ${{ github.actor }} issued <https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}|a new release ${{ github.ref_name }}> of deepnote-toolkit on production.\nPlease <${{ steps.update-ops.outputs.pr_url }}|review, approve, and merge the version-update PR> to start the rollout."
+            }
+
+      - name: Notify Slack - ops production PR failed
+        if: always() && steps.update-ops.outcome == 'failure'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_PRODUCTION }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "icon_emoji": ":nervous-laughter:",
+              "text": ${{ toJSON(format('Failed to create ops version-update PR for deepnote-toolkit {0}. Error: {1}', github.ref_name, steps.update-ops.outputs.error_message || 'Unknown error')) }}
+            }
+
       - name: Update app-config repo multi-tenant production version
+        id: update-app-config
         uses: ./.github/actions/update-config-version
         with:
           env: production
@@ -533,3 +559,27 @@ jobs:
           target_repo: app-config
           branch: main
           github_token: ${{ secrets.DEEPNOTE_BOT_USER_TOKEN }}
+
+      - name: Notify Slack - app-config production PR created
+        if: always() && steps.update-app-config.outcome == 'success' && steps.update-app-config.outputs.pr_url != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_PRODUCTION }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "icon_emoji": ":deepnote:",
+              "text": ":loading: ${{ github.actor }} issued <https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}|a new release ${{ github.ref_name }}> of deepnote-toolkit on production.\nPlease <${{ steps.update-app-config.outputs.pr_url }}|review, approve, and merge the version-update PR> to start the rollout."
+            }
+
+      - name: Notify Slack - app-config production PR failed
+        if: always() && steps.update-app-config.outcome == 'failure'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_PRODUCTION }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "icon_emoji": ":nervous-laughter:",
+              "text": ${{ toJSON(format('Failed to create app-config version-update PR for deepnote-toolkit {0}. Error: {1}', github.ref_name, steps.update-app-config.outputs.error_message || 'Unknown error')) }}
+            }


### PR DESCRIPTION
## Summary
- add Slack notifications for production bump PRs in `ops` and `app-config`
- keep the Slack webhook in the workflow instead of the composite action
- expose Octopilot PR/error outputs and escape failure messages safely


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack notifications for production releases that announce created PRs and report failures with error details.

* **Improvements**
  * Actions now surface PR URLs and error messages for clearer reporting.
  * Notification logic enhanced to show success/failure context, improving visibility and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->