### PR TITLE
fix: pass integration env vars to Streamlit apps

### DIFF
--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -333,7 +333,14 @@ def bootstrap():
     from deepnote_core.runtime.types import StreamlitSpec
 
     if cfg.server.start_streamlit_servers:
-        from .module.streamlit import fetch_streamlit_apps
+        from .module.streamlit import fetch_streamlit_apps, set_integration_env_vars
+
+        # Fetch and set integration env vars before starting Streamlit so that
+        # Streamlit subprocesses inherit them via os.environ.
+        try:
+            set_integration_env_vars(logger)
+        except Exception:
+            logger.exception("Failed to set integration env vars")
 
         try:
             streamlit_apps = fetch_streamlit_apps(logger)

--- a/installer/module/streamlit.py
+++ b/installer/module/streamlit.py
@@ -91,14 +91,10 @@ def fetch_integration_env_vars(logger: logging.Logger) -> List[dict]:
             timeout=timeout,
         )
         variables = json.loads(json_content)
-        logger.info(
-            f"Fetched {len(variables)} integration environment variables."
-        )
+        logger.info(f"Fetched {len(variables)} integration environment variables.")
         return variables
     except urllib.error.URLError as e:
-        logger.error(
-            f"Network error while fetching integration env vars: {e}"
-        )
+        logger.error(f"Network error while fetching integration env vars: {e}")
     except json.JSONDecodeError as e:
         logger.error(f"JSON parsing error: {e}")
     except Exception as e:

--- a/installer/module/streamlit.py
+++ b/installer/module/streamlit.py
@@ -70,6 +70,67 @@ def fetch_streamlit_apps(logger: logging.Logger) -> List[dict]:
     return streamlit_apps
 
 
+def fetch_integration_env_vars(logger: logging.Logger) -> List[dict]:
+    """Fetches integration environment variables from the WebApp.
+
+    Returns a list of dicts with 'name' and 'value' keys.
+    """
+    base_url = get_webapp_url()
+    url = f"{base_url}/integrations/environment-variables"
+
+    timeout = 3
+    max_retries = 3
+
+    logger.info(f"Fetching integration environment variables from {url}.")
+
+    try:
+        json_content = request_with_retries(
+            logger,
+            url,
+            max_retries=max_retries,
+            timeout=timeout,
+        )
+        variables = json.loads(json_content)
+        logger.info(
+            f"Fetched {len(variables)} integration environment variables."
+        )
+        return variables
+    except urllib.error.URLError as e:
+        logger.error(
+            f"Network error while fetching integration env vars: {e}"
+        )
+    except json.JSONDecodeError as e:
+        logger.error(f"JSON parsing error: {e}")
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+
+    return []
+
+
+def set_integration_env_vars(logger: logging.Logger) -> None:
+    """Fetches integration env vars and sets them in os.environ.
+
+    This ensures that Streamlit processes (and other subprocesses started
+    after this call) inherit integration environment variables.
+    """
+    variables = fetch_integration_env_vars(logger)
+    for variable in variables:
+        if not isinstance(variable, dict):
+            logger.warning("Skipping integration env var entry with invalid shape.")
+            continue
+        name = variable.get("name")
+        value = variable.get("value")
+        if not isinstance(name, str) or not isinstance(value, str):
+            continue
+        if not name or "=" in name or "\0" in name:
+            logger.warning(f"Skipping invalid env var name: {name!r}")
+            continue
+        if "\0" in value:
+            logger.warning(f"Skipping env var with invalid value bytes: {name!r}")
+            continue
+        os.environ[name] = value
+
+
 def start_streamlit_servers(
     venv: VirtualEnvironment, logger: logging.Logger
 ) -> List[str]:

--- a/installer/module/streamlit.py
+++ b/installer/module/streamlit.py
@@ -91,14 +91,20 @@ def fetch_integration_env_vars(logger: logging.Logger) -> List[dict]:
             timeout=timeout,
         )
         variables = json.loads(json_content)
+        if not isinstance(variables, list):
+            logger.error(
+                "Invalid integration env vars payload type: expected list, "
+                f"got {type(variables).__name__}."
+            )
+            return []
         logger.info(f"Fetched {len(variables)} integration environment variables.")
         return variables
-    except urllib.error.URLError as e:
-        logger.error(f"Network error while fetching integration env vars: {e}")
-    except json.JSONDecodeError as e:
-        logger.error(f"JSON parsing error: {e}")
-    except Exception as e:
-        logger.error(f"Unexpected error: {e}")
+    except urllib.error.URLError:
+        logger.exception("Network error while fetching integration env vars.")
+    except json.JSONDecodeError:
+        logger.exception("JSON parsing error while fetching integration env vars.")
+    except Exception:
+        logger.exception("Unexpected error while fetching integration env vars.")
 
     return []
 

--- a/tests/unit/test_streamlit.py
+++ b/tests/unit/test_streamlit.py
@@ -52,7 +52,10 @@ class TestFetchStreamlitApps(unittest.TestCase):
 
 
 class TestFetchIntegrationEnvVars(unittest.TestCase):
-    def test_fetch_integration_env_vars(self):
+    """Tests for fetching integration env vars from the WebApp."""
+
+    def test_fetch_integration_env_vars(self) -> None:
+        """Returns the parsed list of env var dicts on success."""
         mock_data = [
             {"name": "SNOWFLAKE_USER", "value": "admin"},
             {"name": "SNOWFLAKE_PASSWORD", "value": "secret123"},
@@ -74,7 +77,8 @@ class TestFetchIntegrationEnvVars(unittest.TestCase):
 
             self.assertEqual(variables, mock_data)
 
-    def test_fetch_integration_env_vars_empty(self):
+    def test_fetch_integration_env_vars_empty(self) -> None:
+        """Returns an empty list when the endpoint returns no vars."""
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps([]).encode("utf-8")
 
@@ -86,7 +90,8 @@ class TestFetchIntegrationEnvVars(unittest.TestCase):
 
             self.assertEqual(variables, [])
 
-    def test_fetch_integration_env_vars_network_error(self):
+    def test_fetch_integration_env_vars_network_error(self) -> None:
+        """Returns an empty list when a network error occurs."""
         import urllib.error
 
         with patch("urllib.request.urlopen") as mock_urlopen:
@@ -97,9 +102,30 @@ class TestFetchIntegrationEnvVars(unittest.TestCase):
 
             self.assertEqual(variables, [])
 
+    def test_fetch_integration_env_vars_non_list_payload(self) -> None:
+        """Returns an empty list when the payload is not a list."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"unexpected": "shape"}).encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__.return_value = mock_response
+
+            test_logger = logging.getLogger("testLogger")
+            variables = fetch_integration_env_vars(test_logger)
+
+            self.assertEqual(variables, [])
+
 
 class TestSetIntegrationEnvVars(unittest.TestCase):
-    def test_set_integration_env_vars(self):
+    """Tests for setting integration env vars in os.environ."""
+
+    def test_set_integration_env_vars(self) -> None:
+        """Valid env vars are set in os.environ."""
+        self.addCleanup(os.environ.pop, "TEST_INT_VAR_A", None)
+        self.addCleanup(os.environ.pop, "TEST_INT_VAR_B", None)
+
         mock_data = [
             {"name": "TEST_INT_VAR_A", "value": "value_a"},
             {"name": "TEST_INT_VAR_B", "value": "value_b"},
@@ -117,11 +143,10 @@ class TestSetIntegrationEnvVars(unittest.TestCase):
             self.assertEqual(os.environ.get("TEST_INT_VAR_A"), "value_a")
             self.assertEqual(os.environ.get("TEST_INT_VAR_B"), "value_b")
 
-        # Cleanup
-        os.environ.pop("TEST_INT_VAR_A", None)
-        os.environ.pop("TEST_INT_VAR_B", None)
+    def test_set_integration_env_vars_skips_invalid_entries(self) -> None:
+        """Invalid entries are skipped without affecting valid ones."""
+        self.addCleanup(os.environ.pop, "TEST_INT_VAR_C", None)
 
-    def test_set_integration_env_vars_skips_invalid_entries(self):
         mock_data = [
             {"name": "TEST_INT_VAR_C", "value": "value_c"},
             {"name": None, "value": "orphan_value"},
@@ -133,6 +158,7 @@ class TestSetIntegrationEnvVars(unittest.TestCase):
             "not_a_dict_entry",
             42,
             {"name": "NULL_BYTE_VAL", "value": "bad\0value"},
+            {"name": "BAD\0NAME", "value": "null_byte_name"},
         ]
 
         mock_response = MagicMock()
@@ -149,6 +175,4 @@ class TestSetIntegrationEnvVars(unittest.TestCase):
             self.assertNotIn("HAS=EQUALS", os.environ)
             self.assertNotIn("GOOD_KEY", os.environ)
             self.assertNotIn("NULL_BYTE_VAL", os.environ)
-
-        # Cleanup
-        os.environ.pop("TEST_INT_VAR_C", None)
+            self.assertNotIn("BAD\0NAME", os.environ)

--- a/tests/unit/test_streamlit.py
+++ b/tests/unit/test_streamlit.py
@@ -59,9 +59,7 @@ class TestFetchIntegrationEnvVars(unittest.TestCase):
         ]
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(mock_data).encode(
-            "utf-8"
-        )
+        mock_response.read.return_value = json.dumps(mock_data).encode("utf-8")
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -92,9 +90,7 @@ class TestFetchIntegrationEnvVars(unittest.TestCase):
         import urllib.error
 
         with patch("urllib.request.urlopen") as mock_urlopen:
-            mock_urlopen.side_effect = urllib.error.URLError(
-                "connection refused"
-            )
+            mock_urlopen.side_effect = urllib.error.URLError("connection refused")
 
             test_logger = logging.getLogger("testLogger")
             variables = fetch_integration_env_vars(test_logger)
@@ -110,9 +106,7 @@ class TestSetIntegrationEnvVars(unittest.TestCase):
         ]
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(mock_data).encode(
-            "utf-8"
-        )
+        mock_response.read.return_value = json.dumps(mock_data).encode("utf-8")
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -142,9 +136,7 @@ class TestSetIntegrationEnvVars(unittest.TestCase):
         ]
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(mock_data).encode(
-            "utf-8"
-        )
+        mock_response.read.return_value = json.dumps(mock_data).encode("utf-8")
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.return_value.__enter__.return_value = mock_response

--- a/tests/unit/test_streamlit.py
+++ b/tests/unit/test_streamlit.py
@@ -1,9 +1,14 @@
 import json
 import logging
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-from installer.module.streamlit import fetch_streamlit_apps
+from installer.module.streamlit import (
+    fetch_integration_env_vars,
+    fetch_streamlit_apps,
+    set_integration_env_vars,
+)
 
 
 class TestFetchStreamlitApps(unittest.TestCase):
@@ -44,3 +49,114 @@ class TestFetchStreamlitApps(unittest.TestCase):
                     }
                 ],
             )
+
+
+class TestFetchIntegrationEnvVars(unittest.TestCase):
+    def test_fetch_integration_env_vars(self):
+        mock_data = [
+            {"name": "SNOWFLAKE_USER", "value": "admin"},
+            {"name": "SNOWFLAKE_PASSWORD", "value": "secret123"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_data).encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__.return_value = mock_response
+
+            test_logger = logging.getLogger("testLogger")
+            variables = fetch_integration_env_vars(test_logger)
+
+            mock_urlopen.assert_called_once_with(
+                "http://localhost:19456/userpod-api/integrations/environment-variables",
+                timeout=3,
+            )
+
+            self.assertEqual(variables, mock_data)
+
+    def test_fetch_integration_env_vars_empty(self):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps([]).encode("utf-8")
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__.return_value = mock_response
+
+            test_logger = logging.getLogger("testLogger")
+            variables = fetch_integration_env_vars(test_logger)
+
+            self.assertEqual(variables, [])
+
+    def test_fetch_integration_env_vars_network_error(self):
+        import urllib.error
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.URLError(
+                "connection refused"
+            )
+
+            test_logger = logging.getLogger("testLogger")
+            variables = fetch_integration_env_vars(test_logger)
+
+            self.assertEqual(variables, [])
+
+
+class TestSetIntegrationEnvVars(unittest.TestCase):
+    def test_set_integration_env_vars(self):
+        mock_data = [
+            {"name": "TEST_INT_VAR_A", "value": "value_a"},
+            {"name": "TEST_INT_VAR_B", "value": "value_b"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_data).encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__.return_value = mock_response
+
+            test_logger = logging.getLogger("testLogger")
+            set_integration_env_vars(test_logger)
+
+            self.assertEqual(os.environ.get("TEST_INT_VAR_A"), "value_a")
+            self.assertEqual(os.environ.get("TEST_INT_VAR_B"), "value_b")
+
+        # Cleanup
+        os.environ.pop("TEST_INT_VAR_A", None)
+        os.environ.pop("TEST_INT_VAR_B", None)
+
+    def test_set_integration_env_vars_skips_invalid_entries(self):
+        mock_data = [
+            {"name": "TEST_INT_VAR_C", "value": "value_c"},
+            {"name": None, "value": "orphan_value"},
+            {"name": "TEST_INT_VAR_D", "value": None},
+            {"name": "", "value": "empty_key"},
+            {"name": "HAS=EQUALS", "value": "bad"},
+            {"name": 123, "value": "non_string_key"},
+            {"name": "GOOD_KEY", "value": 456},
+            "not_a_dict_entry",
+            42,
+            {"name": "NULL_BYTE_VAL", "value": "bad\0value"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_data).encode(
+            "utf-8"
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__.return_value = mock_response
+
+            test_logger = logging.getLogger("testLogger")
+            set_integration_env_vars(test_logger)
+
+            self.assertEqual(os.environ.get("TEST_INT_VAR_C"), "value_c")
+            self.assertNotIn("TEST_INT_VAR_D", os.environ)
+            self.assertNotIn("HAS=EQUALS", os.environ)
+            self.assertNotIn("GOOD_KEY", os.environ)
+            self.assertNotIn("NULL_BYTE_VAL", os.environ)
+
+        # Cleanup
+        os.environ.pop("TEST_INT_VAR_C", None)


### PR DESCRIPTION
## Summary

Fixes an issue where Streamlit apps couldn't access environment variables from integrations.

### Root Cause

Streamlit processes are started by the installer during bootstrap (Phase 12 of `installer/__main__.py`). At that point, integration env vars haven't been fetched yet — they're only fetched later by the Jupyter kernel's `init_deepnote_runtime()` → `set_integration_env()`, which runs in a **separate process**. The Streamlit subprocess snapshots `os.environ` at start time (`ServerProcess._start()` calls `os.environ.copy()`), so it never sees the integration env vars.

### Fix

Before starting Streamlit processes in the installer, fetch integration env vars from the existing webapp endpoint (`/integrations/environment-variables`) and set them in `os.environ`. This way Streamlit subprocesses inherit the vars.

Input validation covers:
- Type checks (`isinstance` for both name/value as `str`)
- Non-dict list entries are skipped with a warning
- Empty names, names containing `=`, and null bytes in names/values are rejected
- `logger.exception` used in the top-level catch block for full traceback

### Files Changed

- `installer/module/streamlit.py`: Added `fetch_integration_env_vars()` and `set_integration_env_vars()` functions with input validation
- `installer/__main__.py`: Call `set_integration_env_vars()` before starting Streamlit apps
- `tests/unit/test_streamlit.py`: Unit tests for fetch, set, validation, and error handling (including non-dict entries and null-byte values)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer fetches and applies integration environment variables so Streamlit subprocesses inherit configured settings at startup.

* **Improvements**
  * Fetching/parsing is resilient: errors, malformed payloads, or invalid entries are logged and skipped without interrupting startup or app discovery.

* **Tests**
  * Added unit tests covering retrieval, handling of empty/non-list responses, network failures, and safe application/skipping of invalid entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnote/deepnote-toolkit/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->