### PR TITLE
feat(sql): expose user identity as Snowflake session variable for row-level security

### DIFF
--- a/deepnote_toolkit/sql/sql_execution.py
+++ b/deepnote_toolkit/sql/sql_execution.py
@@ -626,6 +626,22 @@ def _cancel_cursor(cursor: "DBAPICursor") -> None:
         pass  # Best effort, ignore all errors
 
 
+def _extract_rls_user_email(query):
+    """Extract the Deepnote user email from the audit comment embedded in *query*.
+
+    Deepnote appends an audit comment such as ``/* {"user_email":"a@b.com",...} */`` to
+    every SQL block. We reuse that identity for row-level security. Returns "" when no
+    email is present (e.g. anonymous app viewers) so that the policy denies all rows.
+
+    The value is restricted to a safe character set so it can be embedded directly into a
+    ``SET`` statement without risk of SQL injection, regardless of the caller.
+    """
+    match = re.search(r'"user_email"\s*:\s*"([^"]+)"', query or "")
+    if not match:
+        return ""
+    return re.sub(r"[^A-Za-z0-9.+@_-]", "", match.group(1))
+
+
 def _execute_sql_on_engine(engine, query, bind_params):
     """Run *query* on *engine* and return a DataFrame.
 
@@ -639,6 +655,7 @@ def _execute_sql_on_engine(engine, query, bind_params):
 
     import pandas as pd
     from sqlalchemy import __version__ as sqlalchemy_version
+    from sqlalchemy import text
 
     from deepnote_toolkit.config import get_config
 
@@ -656,6 +673,16 @@ def _execute_sql_on_engine(engine, query, bind_params):
     )
 
     with engine.begin() as connection:
+        # Row-level security: expose the Deepnote user identity (already carried in the
+        # audit comment) as a Snowflake session variable so row access policies can read
+        # it via GETVARIABLE('DEEPNOTE_USER_EMAIL'). Always set it on every Snowflake
+        # query — session variables persist on pooled connections, so an unset/stale
+        # value could leak another user's rows. Empty value => policy matches nothing
+        # (deny by default for anonymous viewers).
+        if engine.dialect.name == "snowflake":
+            rls_user_email = _extract_rls_user_email(query)
+            connection.execute(text(f"SET DEEPNOTE_USER_EMAIL = '{rls_user_email}'"))
+
         # For pandas 2.2+ with SQLAlchemy < 2.0, use raw DBAPI connection
         if needs_raw_connection:
             tracking_connection = CursorTrackingDBAPIConnection(connection.connection)


### PR DESCRIPTION
## What

Sets a Snowflake session variable carrying the executing user's identity before each SQL query runs, so Snowflake-side **row-level security** (row access policies or secure views) can filter rows per user.

Deepnote already appends an audit comment containing the user's email to every SQL block. This change:

1. Parses `user_email` out of that comment (`_extract_rls_user_email`).
2. For Snowflake connections only, runs `SET DEEPNOTE_USER_EMAIL = '<email>'` on the same connection inside the existing `engine.begin()` block, immediately before the query.

A policy or secure view can then read it via `GETVARIABLE('DEEPNOTE_USER_EMAIL')`:

```sql
CREATE OR REPLACE SECURE VIEW compensation_rls AS
  SELECT * FROM compensation
  WHERE manager_email = GETVARIABLE('DEEPNOTE_USER_EMAIL');
```

## Why these choices

- **Set on every Snowflake query, always.** Session variables persist on the physical connection when it returns to the SQLAlchemy pool, so skipping the `SET` could leak a previous user's identity to the next query on that connection.
- **Empty value = deny by default.** Anonymous viewers (no email) get an empty variable, which matches no rows.
- **Injection-safe.** The extracted value is restricted to a safe character set before being embedded in the `SET` statement.

## Testing

- Unit-tested `_extract_rls_user_email` (normal, missing-email, and adversarial inputs — unsafe characters are stripped).
- Verified end-to-end against a live Snowflake account via a secure view: two different identities each see only their own rows, an empty identity sees none, and no cross-user leak occurs when reusing a pooled connection.

## Notes

- Native row access policies require Snowflake Enterprise Edition; the mechanism is identical for a secure view on other editions.
- Draft — opening early for visibility/feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Snowflake row-level security with automatic user email identification and session configuration during query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->