### PR TITLE
fix: log S3 response body on cache upload failure

### DIFF
--- a/deepnote_toolkit/sql/sql_caching.py
+++ b/deepnote_toolkit/sql/sql_caching.py
@@ -111,9 +111,12 @@ def upload_sql_cache(dataframe, upload_url):
             response = requests.put(upload_url, data=temp_file)
             response.raise_for_status()
     except Exception as exc:
+        detail = str(exc)
+        if isinstance(exc, requests.HTTPError) and exc.response is not None:
+            detail = f"{exc.response.status_code} {exc.response.text[:500]}"
         logger.error(
             "Failed to upload SQL cache: %s",
-            exc,
+            detail,
             extra={"sql_caching_cause": "failed_to_upload_to_cache"},
         )
 

--- a/tests/unit/test_sql_caching.py
+++ b/tests/unit/test_sql_caching.py
@@ -399,8 +399,12 @@ class TestUploadSqlCache(unittest.TestCase):
     @patch("deepnote_toolkit.sql.sql_caching.logger")
     @patch("deepnote_toolkit.sql.sql_caching.requests.put")
     def test_http_error_logs_response_body(self, mock_put, mock_logger):
+        upload_url = "https://example.com/upload?signature=secret"
         response = requests.Response()
         response.status_code = 403
+        # raise_for_status() embeds response.url in str(exc), so the presigned
+        # URL only stays out of the log if we never format the exception itself
+        response.url = upload_url
         response._content = (
             b'<?xml version="1.0"?><Error>'
             b"<Code>AccessDenied</Code>"
@@ -409,12 +413,12 @@ class TestUploadSqlCache(unittest.TestCase):
         )
         mock_put.return_value = response
 
-        upload_sql_cache(pd.DataFrame({"a": [1]}), "https://example.com/upload")
+        upload_sql_cache(pd.DataFrame({"a": [1]}), upload_url)
 
         logged = mock_logger.error.call_args.args[1]
         self.assertIn("403", logged)
         self.assertIn("AccessDenied", logged)
-        self.assertNotIn("example.com/upload", logged)
+        self.assertNotIn(upload_url, logged)
 
     @patch("deepnote_toolkit.sql.sql_caching.logger")
     @patch("deepnote_toolkit.sql.sql_caching.requests.put")

--- a/tests/unit/test_sql_caching.py
+++ b/tests/unit/test_sql_caching.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pandas as pd
+import requests
 from parameterized import parameterized
 from pyarrow import ArrowInvalid
 
@@ -394,3 +395,33 @@ class TestUploadSqlCache(unittest.TestCase):
 
         self.assertEqual(pickle_pos, 0, "file should be at position 0")
         self.assertEqual(pickle_size, 0, "file should be empty after truncate")
+
+    @patch("deepnote_toolkit.sql.sql_caching.logger")
+    @patch("deepnote_toolkit.sql.sql_caching.requests.put")
+    def test_http_error_logs_response_body(self, mock_put, mock_logger):
+        response = requests.Response()
+        response.status_code = 403
+        response._content = (
+            b'<?xml version="1.0"?><Error>'
+            b"<Code>AccessDenied</Code>"
+            b"<Message>Request has expired</Message>"
+            b"</Error>"
+        )
+        mock_put.return_value = response
+
+        upload_sql_cache(pd.DataFrame({"a": [1]}), "https://example.com/upload")
+
+        logged = mock_logger.error.call_args.args[1]
+        self.assertIn("403", logged)
+        self.assertIn("AccessDenied", logged)
+        self.assertNotIn("example.com/upload", logged)
+
+    @patch("deepnote_toolkit.sql.sql_caching.logger")
+    @patch("deepnote_toolkit.sql.sql_caching.requests.put")
+    def test_connection_error_logs_str_of_exception(self, mock_put, mock_logger):
+        mock_put.side_effect = requests.ConnectionError("connection timed out")
+
+        upload_sql_cache(pd.DataFrame({"a": [1]}), "https://example.com/upload")
+
+        logged = mock_logger.error.call_args.args[1]
+        self.assertIn("connection timed out", logged)


### PR DESCRIPTION
`raise_for_status()` only surfaces `403 Forbidden` — the S3 XML error body is the only place that distinguishes `AccessDenied` / `Request has expired` / `SignatureDoesNotMatch` / expired presigned URL. This reads `exc.response.text` so the reason reaches the log.

### Before

```
Failed to upload SQL cache: 403 Client Error: Forbidden for url: https://bucket.s3.../cache/abc?X-Amz-Credential=AKIA...&X-Amz-Signature=deadbeef
```

Status code only, no reason. Presigned URL with signing params leaked into the log.

### After

```
Failed to upload SQL cache: 403 <?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>Request has expired</Message><Expires>...</Expires></Error>
```

S3 error body with the actual reason. Presigned URL no longer logged for HTTP errors.

Non-HTTP exceptions (ConnectionError, Timeout) still fall through to `str(exc)` — unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cayDdcs1iuui8Pgh5npKm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL cache upload error messages with HTTP status codes and up to 500 characters of response details.
  * Preserved clear exception messages for connection-related and other non-HTTP failures.
  * Prevented upload URLs from appearing in logged error details.

* **Tests**
  * Added coverage for HTTP and connection error logging.
  * Verified that response details are included safely without exposing sensitive upload URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->