### PR TITLE
fix(chart): Bump deepnote-vegafusion to 2.1.1 for fractional-second timestamps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1495,18 +1495,18 @@ test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "deepnote-vegafusion"
-version = "2.1.0"
+version = "2.1.1"
 description = "Core tools for using VegaFusion from Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepnote_vegafusion-2.1.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3847971dad40d6542b5cf3033379a3f29d7c400dd51adbbba1fe33b5dff152d3"},
-    {file = "deepnote_vegafusion-2.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:5278d0e7d98a54835691308ba3853db19607f17b7d1bc7fdc3874984c50cdb52"},
-    {file = "deepnote_vegafusion-2.1.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76577a98005f8180dc60423a40b9b1f330011dfac2ee846880a5b970d2ca9f21"},
-    {file = "deepnote_vegafusion-2.1.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:56311d3621a44003725431bbf63ab1446b9bedabcba4705769c44d17ce022168"},
-    {file = "deepnote_vegafusion-2.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:45ce94a5fb0b3d3849cd0543ca57cf91416436f35f163c40eb3dd4c91a5c913c"},
-    {file = "deepnote_vegafusion-2.1.0.tar.gz", hash = "sha256:357851e7b6e50674c4f91ba07b373f3ec10b5b50e2815574b856da6e1e008725"},
+    {file = "deepnote_vegafusion-2.1.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a00700ca1cf2b8ea342548ef3a163f20c6d14274f1fcc97a70179121f6dd6c1"},
+    {file = "deepnote_vegafusion-2.1.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6a5273d33e1c507d1ed608fe8566e2de7e9aad74b9ac54875155dbe9872036a4"},
+    {file = "deepnote_vegafusion-2.1.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a70b0d1ab7ad957c7f2f3acadc5c88b5a739150cfb6ee09d8641071debe5256"},
+    {file = "deepnote_vegafusion-2.1.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:128706704db43b7d7faa15e5bc0cc8d0f1b309d9913cd00bb421d82c9a7b188c"},
+    {file = "deepnote_vegafusion-2.1.1-cp39-abi3-win_amd64.whl", hash = "sha256:2e803653c212e8fc742c4ea5b5d0049240188811cb1ab81020c53cd2fc6b7111"},
+    {file = "deepnote_vegafusion-2.1.1.tar.gz", hash = "sha256:9cc74368a22f4248b144d9a96b30cd0fcb85080891dcd2064199bb02ef5f005b"},
 ]
 
 [package.dependencies]
@@ -7449,4 +7449,4 @@ server = ["deepnote-python-lsp-server", "jupyter-resource-usage", "jupyter-serve
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.14"
-content-hash = "3566e573e09e177f019327ea8df4779daf3f7f3e404f0b5de82eb8453b110ee1"
+content-hash = "c774c3f56bb55bf5c3227baed5f6a7b742cc499ac8b5ff17ec286897f81d302e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
     # NOTE: 1.7.0 is latest version of vl-convert which ships with Vega 5. In webapp we can't update to Vega 6 due to ESM-only issues
     # so we keep vl-convert version pinned as well
     "vl-convert-python==1.7.0",
-    "deepnote-vegafusion>=2.1.0,<3",
+    "deepnote-vegafusion>=2.1.1,<3",
     "matplotlib-inline>=0.1.7,<0.2.0; python_version <= '3.10'",  # 0.2.0 is not compatible with matplotlib 3.6.3 on Python <=3.10
     "matplotlib-inline>=0.2.1,<0.3.0; python_version >= '3.11'",
 

--- a/tests/unit/test_chart.py
+++ b/tests/unit/test_chart.py
@@ -246,6 +246,42 @@ class TestDeepnoteChart(unittest.TestCase):
         spec = {"mark": "bar", "encoding": {"x": {"field": "id"}}}
         self._assert_chart_is_json_serializable(df, spec)
 
+    # Regression test for https://github.com/deepnote/vegafusion/releases/tag/v2.1.1:
+    # timestamp strings without a timezone were only parseable with exactly 0 or 3
+    # fractional digits, so microsecond-precision strings (what most databases emit)
+    # failed the whole chart with a parse error.
+    @parameterized.expand(
+        [
+            ("no_fraction", "2024-01-01 10:00:00", "2024-01-01T10:00:00.000"),
+            ("tenths", "2024-01-01 10:00:00.1", "2024-01-01T10:00:00.100"),
+            ("milliseconds", "2024-01-01 10:00:00.123", "2024-01-01T10:00:00.123"),
+            ("microseconds", "2024-01-01 10:00:00.123456", "2024-01-01T10:00:00.123"),
+            (
+                "nanoseconds",
+                "2024-01-01 10:00:00.123456789",
+                "2024-01-01T10:00:00.123",
+            ),
+        ]
+    )
+    def test_timezone_naive_string_timestamps(self, _name, raw_timestamp, expected):
+        df = pd.DataFrame({"ts": [raw_timestamp], "value": [1]})
+        spec = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "ts", "type": "temporal"},
+                "y": {"field": "value", "type": "quantitative"},
+            },
+        }
+
+        chart = DeepnoteChart(df, spec_dict=spec)
+
+        charted_rows = [
+            dataset["values"]
+            for dataset in chart.compiled_vega_spec_dict["data"]
+            if dataset.get("values") and "ts" in dataset["values"][0]
+        ]
+        self.assertEqual(charted_rows, [[{"ts": expected, "value": 1}]])
+
 
 class TestDeepnoteSanitizeDataframe(unittest.TestCase):
     def test_small_dataframe_remains_ordered_the_same(self):

--- a/tests/unit/test_chart.py
+++ b/tests/unit/test_chart.py
@@ -246,10 +246,7 @@ class TestDeepnoteChart(unittest.TestCase):
         spec = {"mark": "bar", "encoding": {"x": {"field": "id"}}}
         self._assert_chart_is_json_serializable(df, spec)
 
-    # Regression test for https://github.com/deepnote/vegafusion/releases/tag/v2.1.1:
-    # timestamp strings without a timezone were only parseable with exactly 0 or 3
-    # fractional digits, so microsecond-precision strings (what most databases emit)
-    # failed the whole chart with a parse error.
+    # Regression test: naive timestamp strings only parsed with 0 or 3 fractional digits.
     @parameterized.expand(
         [
             ("no_fraction", "2024-01-01 10:00:00", "2024-01-01T10:00:00.000"),


### PR DESCRIPTION
## Problem

Charts over string timestamp columns failed outright with:

```
Error parsing timestamp from '2024-01-01 10:00:00.123456' using format '%B %d, %Y %H:%M': input contains invalid characters
```

The named format is a red herring — it is just the last candidate tried. VegaFusion 2.1.0 parsed timezone-naive timestamp strings against a format list whose fractional-second entries were all `%.3f`, so any other precision matched nothing. Timezone-aware strings (`...Z`, `+00:00`) take a different branch and were never affected.

Measured against 2.1.0, by fractional digits: `0` ok, `1` fail, `2` fail, `3` ok, `4` fail, `6` fail, `9` fail. Microsecond precision is what most database drivers emit, so this hit real notebooks.


Before
<img width="978" height="700" alt="image" src="https://github.com/user-attachments/assets/d25db3f1-bcc2-4275-afb6-6272f87d80c1" />

After
<img width="980" height="700" alt="image" src="https://github.com/user-attachments/assets/2a2c540b-8c0b-4410-942e-5488292cbd46" />


## Fix

[deepnote/vegafusion v2.1.1](https://github.com/deepnote/vegafusion/releases/tag/v2.1.1) widens those formats from `%.3f` to `%.f`. This PR bumps the dependency and adds the regression test.

## Test

`TestDeepnoteChart::test_timezone_naive_string_timestamps` builds a real chart through `pre_transform_spec` with a temporal encoding, over 0, 1, 3, 6 and 9 fractional digits, and asserts the compiled Vega spec's inline data.

| | 2.1.0 | 2.1.1 |
|---|---|---|
| `no_fraction`, `milliseconds` | pass | pass |
| `tenths`, `microseconds`, `nanoseconds` | **fail** | pass |

Verified locally on Python 3.13: 3 failed / 2 passed before the bump, 5 passed after. Full local unit suite on 2.1.1: 982 passed, 4 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated supported dependency versions for SQL parsing and charting integrations.

- **Tests**
  - Clarified regression coverage for timestamps with fractional-second precision, including supported formats from whole seconds through nanoseconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->