### PR TITLE
chore(deps): Bump sqlparse to 0.6.0 to clear pip-audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,12 +462,6 @@ jobs:
           inputs: /tmp/requirements-prod.txt
           require-hashes: true
           disable-pip: true
-          # PYSEC-2023-121 (CVE-2022-4899 / GHSA-5c9c-6x87-f9vm)
-          # * incorrectly flags zstd versions >= 1.5.4.0 as vulnerable to CVE-2022-4899
-          # * see https://github.com/pypa/advisory-database/blob/main/vulns/zstd/PYSEC-2023-121.yaml (our version ranges are outside of reported versions)
-          # CVE-2026-0994 (protobuf DoS via nested Any messages in ParseDict)
-          # * no fix version available yet
-          # * low risk: only affects json_format.ParseDict() with untrusted input
           # PYSEC-2024-161 (pyarrow deserialization vulnerability)
           # * false positive: only affects Arrow R package, not PyArrow
           # * see CVE description: "This vulnerability only affects the arrow R package, not other Apache Arrow implementations"
@@ -477,8 +471,6 @@ jobs:
           # * this repo uses PyArrow through pandas parquet IO and Arrow table construction, not IPC file pre-buffering
           # * databricks-sqlalchemy 1.x caps pyarrow<17, but upgrading requires SQLAlchemy 2.x (which is not possible for some Python versions)
           ignore-vulns: &ignore-vulns |
-            PYSEC-2023-121
-            CVE-2026-0994
             PYSEC-2024-161
             PYSEC-2026-113
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -6564,19 +6564,19 @@ tracing = ["opentelemetry-api (>=1.1.0)", "opentelemetry-instrumentation (>=0.20
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 description = "A non-validating SQL parser."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"},
-    {file = "sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e"},
+    {file = "sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f"},
+    {file = "sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9"},
 ]
 
 [package.extras]
 dev = ["build"]
-doc = ["sphinx"]
+doc = ["furo", "sphinx"]
 
 [[package]]
 name = "stack-data"
@@ -7449,4 +7449,4 @@ server = ["deepnote-python-lsp-server", "jupyter-resource-usage", "jupyter-serve
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.14"
-content-hash = "3566e573e09e177f019327ea8df4779daf3f7f3e404f0b5de82eb8453b110ee1"
+content-hash = "3eaf18ec7cc32937e0851f09b8e9c70bd4cb7638a2f6adde2a557a231d982adc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
 
     # SQL templating
     "jinja2>=3.1.6,<4",
-    "sqlparse>=0.4.4,<0.6",
+    "sqlparse>=0.6.0,<0.7",
     "pymysql>=1.1.1,<1.2",
     "pymongo>=4.6.3,<4.10; python_version < '3.13'",
     "pymongo>=4.9.0,<5; python_version>='3.13'",


### PR DESCRIPTION
## Summary

`pip-audit` was failing on **four new advisories in `sqlparse` 0.5.5**, all fixed only in **0.6.0**. Unlike the previous audit PRs, `sqlparse` is a **direct dependency** (`# SQL templating`, `pyproject.toml:85`) and the repo's own `<0.6` cap was what blocked the fix — so this bumps that constraint in place rather than adding an entry to the transitive security-constraint block.

The lock moves `sqlparse` and nothing else.

## Changes

### `pyproject.toml` — direct constraint bump

```diff
     # SQL templating
     "jinja2>=3.1.6,<4",
-    "sqlparse>=0.4.4,<0.6",
+    "sqlparse>=0.6.0,<0.7",
     "pymysql>=1.1.1,<1.2",
```

`<0.7` follows the floor-plus-one-minor style used for the other security bumps (`cryptography>=50.0.0,<51`).

### `poetry.lock` — one package moved

```diff
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
-python-versions = ">=3.8"
+python-versions = ">=3.10"
```

### `.github/workflows/ci.yml` — drop two dead ignore entries

```diff
-          # PYSEC-2023-121 (CVE-2022-4899 / GHSA-5c9c-6x87-f9vm)
-          # * incorrectly flags zstd versions >= 1.5.4.0 as vulnerable to CVE-2022-4899
-          # * see https://github.com/pypa/advisory-database/... (our version ranges are outside of reported versions)
-          # CVE-2026-0994 (protobuf DoS via nested Any messages in ParseDict)
-          # * no fix version available yet
-          # * low risk: only affects json_format.ParseDict() with untrusted input
           # PYSEC-2024-161 (pyarrow deserialization vulnerability)
           ...
           ignore-vulns: &ignore-vulns |
-            PYSEC-2023-121
-            CVE-2026-0994
             PYSEC-2024-161
             PYSEC-2026-113
```

`zstd 1.5.7.2` and `protobuf 5.29.6` now return zero advisories at every pinned version across all Python marker branches, so those two suppressions matched nothing. The two `pyarrow` entries are retained — they still apply to `pyarrow 16.1.0` on Python 3.10/3.11.

## Why `<0.6` was there, and why it's safe to lift

The cap was never about 0.6 — **0.6.0 did not exist when it was written.** It dates from the open-source commit `8b2941b` (2025-10-30), when the newest sqlparse was 0.5.3; 0.6.0 shipped 2026-08-13. The line was untouched in between:

```
$ git log --all --oneline -G'sqlparse>=' -- pyproject.toml
8b2941b Open source Deepnote Toolkit          <- "sqlparse>=0.4.4,<0.6"
```

So it was a routine next-minor ceiling for a 0.x package, matching the repo's other 0.x caps (`db-dtypes<1.4`, `clickhouse-sqlalchemy<0.4`, `pyathena<4`). That caution was earned — this repo was bitten by a sqlparse bump before:

```
8b5825f chore(deps): Bump sqlparse from 0.5.3 to 0.5.4 (#69)
65e194d fix: Revert sqlparse parsing limits to pre-0.5.4 defaults (#77)
```

0.5.4 introduced `MAX_GROUPING_TOKENS=10000`, which broke wide analytical queries; `configure_sqlparse_limits()` exists because of that incident. Worth noting that CVE-2026-54284 was fixed in `sqlparse/sql.py`, **not** by touching the caps — `MAX_GROUPING_TOKENS` / `MAX_GROUPING_DEPTH` keep the same names, module, defaults and `is not None` semantics in 0.6.0, so the #77 workaround is unaffected.

The only breaking change declared in the 0.6.0 CHANGELOG is **dropping Python 3.8/3.9**; this repo is `requires-python = ">=3.10.0,<3.14"`. `tokens.py` and `exceptions.py` are byte-identical between the two versions, and `sqlparse.parse` keeps its signature.

## Per-advisory assessment

Entry point for all of these is `sql_execution.py:78`, which calls `unchain_sql_query()` on **raw cell text before Jinja rendering** — so the parser sees the SQL first, ahead of validation and any DB connection. One cell execution parses the same text several times (`sql_query_chaining.py:15,26,73,132,207`, `sql_execution.py:209`, `sql_caching.py:35`), multiplying any per-parse cost.

| Advisory | What | Reachable here? |
|---|---|---|
| **PYSEC-2026-3696** <br>CVE-2026-59894 | Unescaped backslashes in the `python`/`php` **output filters** let crafted SQL break out of the generated string literal | **No.** The repo never calls `sqlparse.format(..., output_format=...)` — zero hits for `output_format`, `OutputPythonFilter`, `OutputPHPFilter` across `deepnote_toolkit/`, `deepnote_core/`, `installer/`, `tests/`. `google-cloud-spanner` calls `sqlparse.format(query, strip_comments=True)` only (`spanner_dbapi/parse_utils.py:197,228`), not the codegen filters. Fixed as a side effect of the bump. |
| **PYSEC-2026-3697** <br>CVE-2026-71491 | `group_comments` is O(n²) on comment-only statements; reachable via `sqlparse.parse()` **and** `format(strip_comments=True)` | **Yes** — reproduced. Both the repo's `parse()` sites and spanner's `strip_comments=True` path are exposed. |
| **PYSEC-2026-3698** <br>CVE-2026-59893 | ReDoS in the dollar-quoted literal lexer (`keywords.py:33`, backreference `\1`) | **Yes** — reproduced. This one is in the **lexer**, upstream of grouping in `filter_stack.py` (`:31` tokenize → `:41` group), so the grouping caps provide **zero** mitigation even at their strictest setting. Dialect-irrelevant: `sqlparse` loads every keyword dict into one process-wide regex list and the repo never passes dialect info. |
| **PYSEC-2026-3699** <br>CVE-2026-54284 | `TokenList.__init__` flattens the whole subtree per group, burning CPU *before* the depth/token caps trip | **Yes** — reproduced. |

## Measured impact (0.5.5 → 0.6.0)

Same machine, limits configured exactly as the toolkit sets them at runtime (`MAX_GROUPING_TOKENS=None`, `MAX_GROUPING_DEPTH=None` — see `sql_utils.py:32-33`, applied by `runtime_initialization.py:58`):

| Payload | 0.5.5 | 0.6.0 |
|---|---|---|
| benign 994 B query | 0.009 s | 0.006 s |
| 8000 comment lines (39 KB), `parse` — *3697* | **9.307 s** | 0.062 s |
| 8000 comment lines, `format(strip_comments=True)` — *3697* | **9.947 s** | 0.077 s |
| 8000 space-separated `$t<i>$` openers (61 KB) — *3698* | **3.580 s** | 0.245 s |
| nesting depth 1500 (2 KB), `parse` — *3699* | **2.729 s** | 0.024 s |

All three DoS advisories show the same shape: **quadratic on 0.5.5, linear on 0.6.0.**

- *3697*: 2000 lines → 0.583 s, 8000 → 9.307 s (4× input, 16× time).
- *3698*: 1000 → 0.068 s, 2000 → 0.241 s, 4000 → 0.886 s, 8000 → 3.580 s on 0.5.5, versus 0.027 / 0.058 / 0.117 / 0.245 s on 0.6.0 — clean quadratic becoming clean linear, 14.6× at 61 KB.
- *3699*: matches the advisory's "seconds of CPU from a ~2 KB payload" claim.

> **Correction on 3698.** My first payload used *adjacent* openers (`$tag0$$tag1$…`), which accidentally forms `$$` empty-tag delimiters that the regex matches immediately — it measured linear on both versions and I initially recorded 3698 as unreproduced. Space-separating the openers removes the `$$` pairs and reproduces the advisory cleanly, as shown above. The numbers in the table are from the corrected payload.

## Known behavior change (not a blocker)

0.6.0 promotes `MATERIALIZED` and `ROW_FORMAT` to reserved keywords. `extract_table_reference_from_token` (`sql_query_chaining.py:59-63`) discards `Keyword`-typed tokens, so a SQL block whose variable name is *exactly* `materialized` or `row_format` silently stops being chained via `find_query_preview_references`:

```
                                     0.5.5              0.6.0
SELECT * FROM materialized        ['materialized']   []
SELECT * FROM row_format          ['row_format']     []
SELECT * FROM my_materialized_view  ['my_...view']   ['my_...view']   (unaffected)
SELECT * FROM select              []                 []               (already broken)
```

The unit suite does not cover this. It is a pre-existing class of limitation — a block named `select` or `case` fails identically on 0.5.5 today; the reserved-word list just grew by two. Fixing it properly means not discarding keyword tokens in the `expect_table` position, which is a behavior change beyond this PR. Worth knowing if someone reports a chaining break after this lands.

Follow-up on the disabled grouping caps (unchanged by this PR): #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSHPq7nj9cJD8XVPesADtA
